### PR TITLE
Use string eval inside BEGIN blocks to test for non existent modules

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -6,13 +6,13 @@ use Module::Build;
 
 use lib qw(lib);
 use Venn::Dependencies;
-BEGIN { eval { use Venn::LocalBuild; }; }
+BEGIN { eval qq{ use Venn::LocalBuild; }; }
 
 my $fake_builder = Module::Build->new(module_name => 'Venn');
 my @actions = $fake_builder->known_actions;
 my @code;
 for my $action (@actions) {
-    push @code, sprintf('sub ACTION_%s { eval { use Venn::LocalBuild; }; $_[0]->SUPER::ACTION_%s }',
+    push @code, sprintf('sub ACTION_%s { eval qq{ use Venn::LocalBuild; }; $_[0]->SUPER::ACTION_%s }',
                         $action, $action);
 }
 


### PR DESCRIPTION
Using the block form of eval inside a BEGIN block doesn't work.  You
need to use the string form, otherwise, the use statement gets
evaluated first, even though it is seemingly protected inside an eval
block.  Then, if you don't have Venn::LocalBuild, perl Build.PL fails,
instead of quietly ignoring it.
